### PR TITLE
add ability to infer GOPATH from filename

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@
 # linter.py
 # Linter for SublimeLinter3, a code checking framework for Sublime Text 3
 #
-# Written by Jon Surrell
+# Written by Jon Surrell and Jeremy Jay
 # Copyright (c) 2014 Jon Surrell
 #
 # License: MIT
@@ -10,7 +10,8 @@
 
 """This module exports the Golint plugin class."""
 
-from SublimeLinter.lint import Linter, util, highlight
+from SublimeLinter.lint import Linter, util, highlight, persist
+import os
 
 
 class Golint(Linter):
@@ -23,3 +24,41 @@ class Golint(Linter):
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDOUT
     default_type = highlight.WARNING
+
+    def find_gopaths(self):
+
+        # collect existing Go path info
+        goroot = set(os.path.normpath(s) for s in os.environ.get('GOROOT', '').split(os.pathsep))
+        gopath = set(os.path.normpath(s) for s in os.environ.get('GOPATH', '').split(os.pathsep))
+        if '.' in gopath:
+            gopath.remove('.')
+        gopath = list(gopath)
+
+        # search for potential GOPATHs upstream from filename
+        # (reversed to ensure deepest path is first searched)
+        dirparts = os.path.dirname(self.filename).split(os.sep)
+        for i in range(len(dirparts) - 1, 1, -1):
+            if dirparts[i].lower() != "src":
+                continue
+            p = os.path.normpath(os.sep.join(dirparts[:i]))
+            if p not in goroot and p not in gopath:
+                gopath.append(p)
+
+        if persist.debug_mode():
+            persist.printf("{}: {} {}".format(self.name,
+                                              os.path.basename(self.filename or '<unsaved>'),
+                                              "guessed GOPATH=" + os.pathsep.join(gopath)))
+
+        return os.pathsep.join(gopath)
+
+    def run(self, cmd, code):
+
+        self.env = {'GOPATH': self.find_gopaths()}
+
+        # copy debug output from Linter.run()
+        if persist.debug_mode():
+            persist.printf('{}: {} {}'.format(self.name,
+                                              os.path.basename(self.filename or '<unsaved>'),
+                                              cmd or '<builtin>'))
+
+        return self.tmpfile(cmd, code, suffix=self.get_tempfile_suffix())


### PR DESCRIPTION
Similar to GoSublime's "use_gs_gopath" setting - backtrack up the file's
path and add whenever you see a "src" directory.
