### PR TITLE
Fix external dependency on highlight constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ install:
   - pip install pep257
 # command to run tests
 script:
-  - flake8 . --max-line-length=120
-  - pep257 .
+  - flake8 . --max-line-length=120 --ignore=D211
+  - pep257 --ignore=D211 .

--- a/linter.py
+++ b/linter.py
@@ -10,13 +10,15 @@
 
 """This module exports the Golint plugin class."""
 
-from SublimeLinter.lint import Linter, util, persist
 import os
+import SublimeLinter
 
 if getattr(SublimeLinter.lint, 'VERSION', 3) > 3:
-    from SublimeLinter.lint import const
+    from SublimeLinter.lint import const, Linter
+    WARNING = const.WARNING
 else:
-    from SublimeLinter.lint import highlight
+    from SublimeLinter.lint import highlight, Linter
+    WARNING = highlight.WARNING
 
 
 class Golint(Linter):
@@ -27,12 +29,8 @@ class Golint(Linter):
     cmd = 'golint'
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
     tempfile_suffix = 'go'
-    error_stream = util.STREAM_STDOUT
-
-    if getattr(SublimeLinter.lint, 'VERSION', 3) > 3:
-        default_type = const.WARNING
-    else:
-        default_type = highlight.WARNING
+    error_stream = SublimeLinter.lint.util.STREAM_STDOUT
+    default_type = WARNING
 
     def find_gopaths(self):
         """Search for potential GOPATHs."""
@@ -53,8 +51,8 @@ class Golint(Linter):
             if p not in goroot and p not in gopath:
                 gopath.append(p)
 
-        if persist.debug_mode():
-            persist.printf("{}: {} {}".format(self.name,
+        if SublimeLinter.lint.persist.debug_mode():
+            SublimeLinter.lint.persist.printf("{}: {} {}".format(self.name,
                                               os.path.basename(self.filename or '<unsaved>'),
                                               "guessed GOPATH=" + os.pathsep.join(gopath)))
 
@@ -65,8 +63,8 @@ class Golint(Linter):
         self.env = {'GOPATH': self.find_gopaths()}
 
         # copy debug output from Linter.run()
-        if persist.debug_mode():
-            persist.printf('{}: {} {}'.format(self.name,
+        if SublimeLinter.lint.persist.debug_mode():
+            SublimeLinter.lint.persist.printf('{}: {} {}'.format(self.name,
                                               os.path.basename(self.filename or '<unsaved>'),
                                               cmd or '<builtin>'))
 

--- a/linter.py
+++ b/linter.py
@@ -10,7 +10,7 @@
 
 """This module exports the Golint plugin class."""
 
-from SublimeLinter.lint import Linter, util, highlight, persist
+from SublimeLinter.lint import Linter, util, const, persist
 import os
 
 
@@ -23,7 +23,7 @@ class Golint(Linter):
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDOUT
-    default_type = highlight.WARNING
+    default_type = const.WARNING
 
     def find_gopaths(self):
         """search for potential GOPATHs."""

--- a/linter.py
+++ b/linter.py
@@ -13,12 +13,10 @@
 from SublimeLinter.lint import Linter, util, persist
 import os
 
-try:
-    """SublimeLinter v3"""
-    from SublimeLinter.lint import highlight
-except ImportError:
-    """SublimeLinter v4"""
+if getattr(SublimeLinter.lint, 'VERSION', 3) > 3:
     from SublimeLinter.lint import const
+else:
+    from SublimeLinter.lint import highlight
 
 
 class Golint(Linter):
@@ -31,12 +29,10 @@ class Golint(Linter):
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDOUT
 
-    try:
-        """SublimeLinter v3"""
-        default_type = highlight.WARNING
-    except NameError:
-        """SublimeLinter v4"""
+    if getattr(SublimeLinter.lint, 'VERSION', 3) > 3:
         default_type = const.WARNING
+    else:
+        default_type = highlight.WARNING
 
     def find_gopaths(self):
         """Search for potential GOPATHs."""

--- a/linter.py
+++ b/linter.py
@@ -13,7 +13,6 @@
 from SublimeLinter.lint import Linter, util, const, persist
 import os
 
-
 class Golint(Linter):
 
     """Provides an interface to golint."""

--- a/linter.py
+++ b/linter.py
@@ -10,8 +10,15 @@
 
 """This module exports the Golint plugin class."""
 
-from SublimeLinter.lint import Linter, util, const, persist
+from SublimeLinter.lint import Linter, util, persist
 import os
+
+try:
+    """SublimeLinter v3"""
+    from SublimeLinter.lint import highlight
+except ImportError:
+    """SublimeLinter v4"""
+    from SublimeLinter.lint import const
 
 
 class Golint(Linter):
@@ -23,7 +30,13 @@ class Golint(Linter):
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s+(?P<message>.+)'
     tempfile_suffix = 'go'
     error_stream = util.STREAM_STDOUT
-    default_type = const.WARNING
+
+    try:
+        """SublimeLinter v3"""
+        default_type = highlight.WARNING
+    except NameError:
+        """SublimeLinter v4"""
+        default_type = const.WARNING
 
     def find_gopaths(self):
         """Search for potential GOPATHs."""

--- a/linter.py
+++ b/linter.py
@@ -13,6 +13,7 @@
 from SublimeLinter.lint import Linter, util, const, persist
 import os
 
+
 class Golint(Linter):
 
     """Provides an interface to golint."""
@@ -25,7 +26,7 @@ class Golint(Linter):
     default_type = const.WARNING
 
     def find_gopaths(self):
-        """search for potential GOPATHs."""
+        """Search for potential GOPATHs."""
         # collect existing Go path info
         goroot = set(os.path.normpath(s) for s in os.environ.get('GOROOT', '').split(os.pathsep))
         gopath = set(os.path.normpath(s) for s in os.environ.get('GOPATH', '').split(os.pathsep))
@@ -51,7 +52,7 @@ class Golint(Linter):
         return os.pathsep.join(gopath)
 
     def run(self, cmd, code):
-        """transparently add potential GOPATHs before running."""
+        """Transparently add potential GOPATHs before running."""
         self.env = {'GOPATH': self.find_gopaths()}
 
         # copy debug output from Linter.run()


### PR DESCRIPTION
SublimeLinter v4.0.0 introduced a breaking change during the refactoring of the `highlight` module _(exception below)_ which was changed to `const`. This change also affected other linters like "SublimeLinter-annotations" and so we started a campaign to fix all the dependent packages here [1].

[1] https://github.com/SublimeLinter/SublimeLinter/issues/915

```
reloading plugin SublimeLinter-contrib-golint.linter
Traceback (most recent call last):
  File "/sublime_plugin.py", line 109, in reload_plugin
    m = importlib.import_module(modulename)
  File "./python3.3/importlib/__init__.py", line 90, in import_module
  File "<frozen importlib._bootstrap>", line 1584, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1565, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1532, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 584, in _check_name_wrapper
  File "<frozen importlib._bootstrap>", line 1022, in load_module
  File "<frozen importlib._bootstrap>", line 1003, in load_module
  File "<frozen importlib._bootstrap>", line 560, in module_for_loader_wrapper
  File "<frozen importlib._bootstrap>", line 868, in _load_module
  File "<frozen importlib._bootstrap>", line 313, in _call_with_frames_removed
  File "/Packages/SublimeLinter-contrib-golint/linter.py", line 13, in <module>
    from SublimeLinter.lint import Linter, util, highlight, persist
ImportError: cannot import name highlight
```